### PR TITLE
Update Google libs + Godot 4.1.3 support

### DIFF
--- a/config/GodotGooglePlayInAppReview.gdap
+++ b/config/GodotGooglePlayInAppReview.gdap
@@ -2,8 +2,8 @@
 
 name="GodotGooglePlayInAppReview"
 binary_type="local"
-binary="GodotGooglePlayInAppReview.1.0.1.release.aar"
+binary="GodotGooglePlayInAppReview.1.0.2.release.aar"
 
 [dependencies]
 
-remote=["com.google.android.play:core:1.10.2"]
+remote=["com.google.android.play:review:2.0.1"]

--- a/godot-google-play-inapp-review/build.gradle
+++ b/godot-google-play-inapp-review/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.0.3'
+        classpath 'com.android.tools.build:gradle:7.4.2'
         
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/godot-google-play-inapp-review/godot-inappreview/build.gradle
+++ b/godot-google-play-inapp-review/godot-inappreview/build.gradle
@@ -3,14 +3,14 @@ plugins {
 }
 
 ext.pluginVersionCode = 2
-ext.pluginVersionName = "1.0.1"
+ext.pluginVersionName = "1.0.2"
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 33
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 31
+        targetSdkVersion 33
         versionCode pluginVersionCode
         versionName pluginVersionName
 
@@ -34,7 +34,7 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
 
-    implementation 'com.google.android.play:core:1.10.2'
+    implementation 'com.google.android.play:review:2.0.1'
     implementation "androidx.legacy:legacy-support-v4:1.0.0"
 
     compileOnly project(':godot-lib.release')

--- a/godot-google-play-inapp-review/godot-inappreview/src/main/java/ibardinov/godot/plugin/android/inappreview/GodotGooglePlayInAppReview.java
+++ b/godot-google-play-inapp-review/godot-inappreview/src/main/java/ibardinov/godot/plugin/android/inappreview/GodotGooglePlayInAppReview.java
@@ -13,7 +13,7 @@ import java.util.Set;
 import com.google.android.play.core.review.ReviewInfo;
 import com.google.android.play.core.review.ReviewManager;
 import com.google.android.play.core.review.ReviewManagerFactory;
-import com.google.android.play.core.tasks.Task;
+import com.google.android.gms.tasks.Task;
 
 import androidx.annotation.NonNull;
 import androidx.collection.ArraySet;

--- a/godot-google-play-inapp-review/gradle/wrapper/gradle-wrapper.properties
+++ b/godot-google-play-inapp-review/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Jun 13 09:42:50 BRT 2020
+#Wed Mar 27 12:17:14 BRT 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-all.zip


### PR DESCRIPTION
I updated the Google libs to use the newest one, as this was conflicting with another lib I was using that used the newer versions.

Plus I made a release for Godot 4.1.3, you can check it [here](https://github.com/yancouto/Godot-GooglePlay-InApp-Review/releases/tag/v1.0.2). I'm using it because I'm stuck in Godot 4.1 because of some new bugs in Godot 4.2.

For Godot 4.2+ there's a new way to do plugins, plus I already see [some options using that](https://github.com/trash-max/Godot-Android-Rateme).